### PR TITLE
fix: remove the 'placeholder' word in the SDR project link text

### DIFF
--- a/index.html
+++ b/index.html
@@ -692,7 +692,7 @@ visualizations. </td>
               <li>
                 <b>Software Defined Radio Accelerator</b>: Targeting some SDR application designs at ASIC level.
                 <div class="links">
-                  <a href="https://github.com/RainChinChao/heichips25_SDR_new" target="_blank">Repository (placeholder)</a>
+                  <a href="https://github.com/RainChinChao/heichips25_SDR_new" target="_blank">Repository</a>
                   <a href="./presentations-pdf/projects/SDR_Hardware_Acceleration_YUQIN_ZHAO.pdf" target="_blank">Presentation</a>
                 </div>
               </li>


### PR DESCRIPTION
This removes the 'placeholder' word in the link text of the link the SDR project, which was added by accident.