### PR TITLE
fix: create distinct deployment groups for main and preview

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,10 @@ on:
     branches:
       - main
 
-concurrency: gh-pages-deploy
+# Must NOT share a group with preview.yml: merging a PR fires this workflow and
+# the preview cleanup simultaneously, and a later run entering the group cancels
+# whichever one is still queued.
+concurrency: gh-pages-deploy-main
 
 jobs:
   deploy:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -8,7 +8,9 @@ on:
       - synchronize
       - closed
 
-concurrency: gh-pages-deploy
+# Serializes all preview runs against each other (they push to the same branch),
+# but stays separate from the main deploy group. See deploy.yml.
+concurrency: gh-pages-deploy-preview
 
 jobs:
   deploy-preview:

--- a/index.html
+++ b/index.html
@@ -780,7 +780,6 @@
                 <th>Affiliation</th>
                 <th>Title</th>
                 <!-- <th>Abstract</th> -->
-                <!-- <th>PDF</th> -->
             </tr>
             <!-- Poster 1 -->
             <tr>


### PR DESCRIPTION
This should avoid the deployment to fail if the preview and the main deployment are competing